### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ MCP server implementation for Qase API
 
 This is a TypeScript-based MCP server that provides integration with the Qase test management platform. It implements core MCP concepts by providing tools for interacting with various Qase entities.
 
+<a href="https://glama.ai/mcp/servers/@rikuson/mcp-qase">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rikuson/mcp-qase/badge" alt="QASE Server MCP server" />
+</a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [QASE MCP Server](https://glama.ai/mcp/servers/@rikuson/mcp-qase) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@rikuson/mcp-qase">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rikuson/mcp-qase/badge" alt="QASE Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.